### PR TITLE
PR 5: Deliberate Failure Mode

### DIFF
--- a/mcp-demo/python/rest_to_mcp/models.py
+++ b/mcp-demo/python/rest_to_mcp/models.py
@@ -260,6 +260,28 @@ class ToolValidationError(Exception):
         super().__init__(f"Tool '{tool_name}' validation failed: {'; '.join(errors)}")
 
 
+class ToolTimeoutError(Exception):
+    """
+    Raised when tool execution exceeds allowed time.
+
+    DELIBERATE FAILURE MODE: Timeouts are handled explicitly, not in a
+    generic catch-all. This makes the failure mode visible and allows
+    orchestration to decide how to respond.
+
+    Contains:
+    - tool_name: Which tool timed out
+    - timeout_seconds: How long we waited before giving up
+    """
+
+    def __init__(self, tool_name: str, timeout_seconds: float) -> None:
+        self.tool_name = tool_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"Tool '{tool_name}' timed out after {timeout_seconds}s. "
+            "The external service did not respond in time."
+        )
+
+
 class ExecutionContext:
     """
     Canonical context object — the single source of truth for request state.


### PR DESCRIPTION
## Summary

- Add `ToolTimeoutError` exception for explicit timeout handling
- Handle `httpx.TimeoutException` separately from generic `HTTPError`
- Return structured error response with `failure_mode="timeout"`
- Context preserves tool binding but records no result on timeout

## Key Principle

**EXPLICIT FAILURES**: Timeouts are not hidden in a generic catch-all. Each failure mode is visible and can be handled differently by orchestration.

```python
# BEFORE: Hidden in generic handler
except httpx.HTTPError as e:
    return ToolCallResult(content=[TextContent(text=f"HTTP error: {e}")], isError=True)

# AFTER: Explicit timeout handling
except httpx.TimeoutException:
    raise ToolTimeoutError(name, HTTP_TIMEOUT_SECONDS)  # Visible failure mode

except httpx.HTTPError as e:
    return ToolCallResult(content=[TextContent(text=f"HTTP error: {e}")], isError=True)
```

## Structured Error Response

```json
{
  "error": {
    "code": -32603,
    "message": "Tool 'get_weather' timed out after 30.0s...",
    "data": {
      "tool": "get_weather",
      "timeout_seconds": 30.0,
      "failure_mode": "timeout"
    }
  }
}
```

## Test Plan

- [x] ToolTimeoutError exception message includes tool name and timeout
- [x] ToolTimeoutError exception exposes attributes
- [x] call_tool raises ToolTimeoutError on timeout
- [x] handle_request returns structured timeout error
- [x] Timeout preserves context state (tool bound, no result)
- [x] All 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)