### PR TITLE
PR 6: Domain Adapter Isolation

### DIFF
--- a/mcp-demo/python/rest_to_mcp/domains/__init__.py
+++ b/mcp-demo/python/rest_to_mcp/domains/__init__.py
@@ -1,0 +1,22 @@
+"""
+Domain Adapters
+
+Each domain module contains endpoints and transformations specific to one API.
+This isolation ensures adding/removing a domain is a single-file operation.
+
+To add a new domain:
+1. Create domains/newdomain.py with NEWDOMAIN_ENDPOINTS list
+2. Import in endpoints.py and add to DEFAULT_ENDPOINTS
+
+To remove a domain:
+1. Delete domains/domainname.py
+2. Remove import from endpoints.py
+"""
+
+from .jsonplaceholder import JSONPLACEHOLDER_ENDPOINTS
+from .openmeteo import OPEN_METEO_ENDPOINTS
+
+__all__ = [
+    "JSONPLACEHOLDER_ENDPOINTS",
+    "OPEN_METEO_ENDPOINTS",
+]

--- a/mcp-demo/python/rest_to_mcp/domains/jsonplaceholder.py
+++ b/mcp-demo/python/rest_to_mcp/domains/jsonplaceholder.py
@@ -1,0 +1,75 @@
+"""
+JSONPlaceholder API Domain
+
+Endpoints for the JSONPlaceholder fake REST API.
+https://jsonplaceholder.typicode.com
+
+This domain provides:
+- Posts CRUD operations
+- Comments retrieval
+- Users retrieval
+"""
+
+from __future__ import annotations
+
+from ..endpoints import HttpMethod, RestEndpoint
+
+
+JSONPLACEHOLDER_ENDPOINTS: list[RestEndpoint] = [
+    RestEndpoint(
+        name="get_posts",
+        path="/posts",
+        method=HttpMethod.GET,
+        description="Get all posts. Optionally filter by userId.",
+        query_params=["userId"],
+    ),
+    RestEndpoint(
+        name="get_post",
+        path="/posts/{id}",
+        method=HttpMethod.GET,
+        description="Get a specific post by ID.",
+        path_params=["id"],
+    ),
+    RestEndpoint(
+        name="create_post",
+        path="/posts",
+        method=HttpMethod.POST,
+        description="Create a new post with title, body, and userId.",
+        body_params=["title", "body", "userId"],
+    ),
+    RestEndpoint(
+        name="update_post",
+        path="/posts/{id}",
+        method=HttpMethod.PUT,
+        description="Update an existing post.",
+        path_params=["id"],
+        body_params=["title", "body", "userId"],
+    ),
+    RestEndpoint(
+        name="delete_post",
+        path="/posts/{id}",
+        method=HttpMethod.DELETE,
+        description="Delete a post by ID.",
+        path_params=["id"],
+    ),
+    RestEndpoint(
+        name="get_comments",
+        path="/posts/{postId}/comments",
+        method=HttpMethod.GET,
+        description="Get all comments for a specific post.",
+        path_params=["postId"],
+    ),
+    RestEndpoint(
+        name="get_users",
+        path="/users",
+        method=HttpMethod.GET,
+        description="Get all users.",
+    ),
+    RestEndpoint(
+        name="get_user",
+        path="/users/{id}",
+        method=HttpMethod.GET,
+        description="Get a specific user by ID.",
+        path_params=["id"],
+    ),
+]

--- a/mcp-demo/python/rest_to_mcp/domains/openmeteo.py
+++ b/mcp-demo/python/rest_to_mcp/domains/openmeteo.py
@@ -1,0 +1,35 @@
+"""
+Open-Meteo Weather API Domain
+
+Endpoints for the Open-Meteo weather API.
+https://open-meteo.com/en/docs
+
+This domain provides:
+- Current weather conditions
+- 7-day weather forecasts
+"""
+
+from __future__ import annotations
+
+from ..config import OPEN_METEO_BASE_URL
+from ..endpoints import HttpMethod, RestEndpoint
+
+
+OPEN_METEO_ENDPOINTS: list[RestEndpoint] = [
+    RestEndpoint(
+        name="get_weather",
+        path="/v1/forecast",
+        method=HttpMethod.GET,
+        description="Get current weather for coordinates. Returns temperature, wind speed, and conditions.",
+        query_params=["latitude", "longitude", "current_weather"],
+        base_url=OPEN_METEO_BASE_URL,
+    ),
+    RestEndpoint(
+        name="get_forecast",
+        path="/v1/forecast",
+        method=HttpMethod.GET,
+        description="Get 7-day weather forecast for coordinates.",
+        query_params=["latitude", "longitude", "daily", "timezone"],
+        base_url=OPEN_METEO_BASE_URL,
+    ),
+]

--- a/mcp-demo/python/rest_to_mcp/endpoints.py
+++ b/mcp-demo/python/rest_to_mcp/endpoints.py
@@ -1,8 +1,13 @@
 """
 Endpoint definitions for REST-to-MCP adapter.
 
-Separates endpoint data from adapter logic for better maintainability.
-Each API's endpoints are defined as a list of RestEndpoint objects.
+This module contains:
+- Core types: HttpMethod, RestEndpoint
+- Aggregated endpoint lists imported from domain modules
+
+Domain-specific endpoints are isolated in the domains/ package.
+To add a new domain: create domains/newdomain.py and import here.
+To remove a domain: delete the file and remove the import.
 """
 
 from __future__ import annotations
@@ -10,8 +15,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-
-from .config import JSONPLACEHOLDER_BASE_URL, OPEN_METEO_BASE_URL
 
 
 class HttpMethod(str, Enum):
@@ -143,93 +146,11 @@ from .models import Tool  # noqa: E402
 
 
 # -----------------------------------------------------------------------------
-# JSONPlaceholder API Endpoints
-# https://jsonplaceholder.typicode.com
+# Domain Endpoints (imported from isolated domain modules)
 # -----------------------------------------------------------------------------
 
-JSONPLACEHOLDER_ENDPOINTS: list[RestEndpoint] = [
-    RestEndpoint(
-        name="get_posts",
-        path="/posts",
-        method=HttpMethod.GET,
-        description="Get all posts. Optionally filter by userId.",
-        query_params=["userId"],
-    ),
-    RestEndpoint(
-        name="get_post",
-        path="/posts/{id}",
-        method=HttpMethod.GET,
-        description="Get a specific post by ID.",
-        path_params=["id"],
-    ),
-    RestEndpoint(
-        name="create_post",
-        path="/posts",
-        method=HttpMethod.POST,
-        description="Create a new post with title, body, and userId.",
-        body_params=["title", "body", "userId"],
-    ),
-    RestEndpoint(
-        name="update_post",
-        path="/posts/{id}",
-        method=HttpMethod.PUT,
-        description="Update an existing post.",
-        path_params=["id"],
-        body_params=["title", "body", "userId"],
-    ),
-    RestEndpoint(
-        name="delete_post",
-        path="/posts/{id}",
-        method=HttpMethod.DELETE,
-        description="Delete a post by ID.",
-        path_params=["id"],
-    ),
-    RestEndpoint(
-        name="get_comments",
-        path="/posts/{postId}/comments",
-        method=HttpMethod.GET,
-        description="Get all comments for a specific post.",
-        path_params=["postId"],
-    ),
-    RestEndpoint(
-        name="get_users",
-        path="/users",
-        method=HttpMethod.GET,
-        description="Get all users.",
-    ),
-    RestEndpoint(
-        name="get_user",
-        path="/users/{id}",
-        method=HttpMethod.GET,
-        description="Get a specific user by ID.",
-        path_params=["id"],
-    ),
-]
-
-
-# -----------------------------------------------------------------------------
-# Open-Meteo Weather API Endpoints
-# https://open-meteo.com/en/docs
-# -----------------------------------------------------------------------------
-
-OPEN_METEO_ENDPOINTS: list[RestEndpoint] = [
-    RestEndpoint(
-        name="get_weather",
-        path="/v1/forecast",
-        method=HttpMethod.GET,
-        description="Get current weather for coordinates. Returns temperature, wind speed, and conditions.",
-        query_params=["latitude", "longitude", "current_weather"],
-        base_url=OPEN_METEO_BASE_URL,
-    ),
-    RestEndpoint(
-        name="get_forecast",
-        path="/v1/forecast",
-        method=HttpMethod.GET,
-        description="Get 7-day weather forecast for coordinates.",
-        query_params=["latitude", "longitude", "daily", "timezone"],
-        base_url=OPEN_METEO_BASE_URL,
-    ),
-]
+from .domains.jsonplaceholder import JSONPLACEHOLDER_ENDPOINTS
+from .domains.openmeteo import OPEN_METEO_ENDPOINTS
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moved domain-specific endpoint definitions into separate modules under `domains/` package
- Created `domains/jsonplaceholder.py` with JSONPLACEHOLDER_ENDPOINTS
- Created `domains/openmeteo.py` with OPEN_METEO_ENDPOINTS
- Updated `endpoints.py` to import from domains and keep only core types
- Added 5 tests for domain isolation pattern

## Domain Swap Pattern

Adding/removing a domain is now a single-file operation:

**To add a new domain:**
1. Create `domains/newdomain.py` with `NEWDOMAIN_ENDPOINTS` list
2. Import in `endpoints.py` and add to `DEFAULT_ENDPOINTS`

**To remove a domain:**
1. Delete `domains/domainname.py`
2. Remove import from `endpoints.py`

## Test plan

- [x] All 117 tests pass
- [x] Domain modules are importable directly
- [x] Domain endpoints match aggregated lists (identity check)
- [x] JSONPlaceholder endpoints have no per-endpoint base_url
- [x] Open-Meteo endpoints have their own base_url
- [x] Pattern test documents adding new domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)